### PR TITLE
Add TODO comment for formatting Pi example

### DIFF
--- a/exercises/getting-started/06_format_pi.rs
+++ b/exercises/getting-started/06_format_pi.rs
@@ -7,5 +7,6 @@
 
 fn main() {
     let pi = 3.14159;
+    // TODO: update this line to format `pi` with three decimal places
     println!("Pi is", pi);
 }


### PR DESCRIPTION
## Summary
- clarify that the `println!` statement in `06_format_pi.rs` should format Pi to three decimal places

## Testing
- `cargo test`