### PR TITLE
Fix outdated Rust edition in playground links

### DIFF
--- a/exercises/getting-started/01_customize_hello.rs
+++ b/exercises/getting-started/01_customize_hello.rs
@@ -3,7 +3,7 @@
 // Try changing the greeting to include your name or something fun.
 //
 // ▶️ Run in Playground:
-// https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&code=fn%20main%28%29%20%7B%0A%20%20%20%20println%21%28%22Hello%2C%20world%21%22%29%3B%0A%7D
+// https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=fn%20main%28%29%20%7B%0A%20%20%20%20println%21%28%22Hello%2C%20world%21%22%29%3B%0A%7D
 
 fn main() {
     println!("Hello, world!");

--- a/exercises/getting-started/02_variable_greeting.rs
+++ b/exercises/getting-started/02_variable_greeting.rs
@@ -3,7 +3,7 @@
 // Then print it using both {} and {message} styles.
 //
 // ▶️ Run in Playground:
-https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&code=fn%20main%28%29%20%7B%0A%20%20let%20message%20%3D%20%22Hello%2C%20world%21%22%3B%0A%0A%20%20println%21%28%22%22%29%3B%20%2F%2F%20Traditional%20style%0A%20%20println%21%28%22%22%29%3B%20%2F%2F%20Shorthand%20style%20%28Rust%201.58%2B%29%0A%7D
+https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=fn%20main%28%29%20%7B%0A%20%20let%20message%20%3D%20%22Hello%2C%20world%21%22%3B%0A%0A%20%20println%21%28%22%22%29%3B%20%2F%2F%20Traditional%20style%0A%20%20println%21%28%22%22%29%3B%20%2F%2F%20Shorthand%20style%20%28Rust%201.58%2B%29%0A%7D
 
 Let me know when you're ready for the next exercise block.
 

--- a/exercises/getting-started/03_prompt_personalized.rs
+++ b/exercises/getting-started/03_prompt_personalized.rs
@@ -3,7 +3,7 @@
 // "It's great to meet you, Anika!"
 //
 // ▶️ Run in Playground:
-// https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=b43435813f8f0d463f41ebd926c3f3a7
+// https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b43435813f8f0d463f41ebd926c3f3a7
 
 use std::io;
 

--- a/exercises/getting-started/04_full_name_flex.rs
+++ b/exercises/getting-started/04_full_name_flex.rs
@@ -3,7 +3,7 @@
 // OR change the final output to print in "Last, First" format.
 //
 // ▶️ Run in Playground:
-// https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=1548445aa86f6938036cf68c738606a2
+// https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=1548445aa86f6938036cf68c738606a2
 
 use std::io;
 

--- a/exercises/getting-started/05_format_variable.rs
+++ b/exercises/getting-started/05_format_variable.rs
@@ -3,7 +3,7 @@
 // Then print that variable using `println!`.
 //
 // ▶️ Run in Playground:
-// https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=b8ca149db3033e1d60008e4f14470815
+// https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=b8ca149db3033e1d60008e4f14470815
 
 fn main() {
     let name = "Anika";

--- a/main/functions.md
+++ b/main/functions.md
@@ -22,7 +22,7 @@ fn main() {
 }
 ```
 
-▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&code=fn+say_hello%28%29+%7B%0A++++println%21%28%22Hello+from+a+function%21%22%29%3B%0A%7D%0A%0Afn+main%28%29+%7B%0A++++say_hello%28%29%3B%0A%7D)
+▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=fn+say_hello%28%29+%7B%0A++++println%21%28%22Hello+from+a+function%21%22%29%3B%0A%7D%0A%0Afn+main%28%29+%7B%0A++++say_hello%28%29%3B%0A%7D)
 
 ## 2. Functions with Parameters
 
@@ -40,7 +40,7 @@ fn main() {
 }
 ```
 
-▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&code=fn+greet%28name%3A+%26str%29+%7B%0A++++println%21%28%22Hello%2C+%7B%7D%21%22%2C+name%29%3B%0A%7D%0A%0Afn+main%28%29+%7B%0A++++greet%28%22Alice%22%29%3B%0A%7D)
+▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=fn+greet%28name%3A+%26str%29+%7B%0A++++println%21%28%22Hello%2C+%7B%7D%21%22%2C+name%29%3B%0A%7D%0A%0Afn+main%28%29+%7B%0A++++greet%28%22Alice%22%29%3B%0A%7D)
 
 ## 3. Functions That Return Values
 
@@ -59,7 +59,7 @@ fn main() {
 }
 ```
 
-▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&code=fn+square%28n%3A+i32%29+-%3E+i32+%7B%0A++++n+*+n%0A%7D%0A%0Afn+main%28%29+%7B%0A++++let+result+%3D+square%284%29%3B%0A++++println%21%28%224+squared+is+%7B%7D%22%2C+result%29%3B%0A%7D)
+▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=fn+square%28n%3A+i32%29+-%3E+i32+%7B%0A++++n+*+n%0A%7D%0A%0Afn+main%28%29+%7B%0A++++let+result+%3D+square%284%29%3B%0A++++println%21%28%224+squared+is+%7B%7D%22%2C+result%29%3B%0A%7D)
 
 ## 4. Notes on Return Types
 

--- a/main/getting-started.md
+++ b/main/getting-started.md
@@ -13,7 +13,7 @@ fn main() {
     println!("Hello, world!");
 }
 ```
-▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&code=fn+main%28%29+%7B%0D%0A++++println%21%28%22Hello%2C+world%21%22%29%3B%0D%0A%7D)
+▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=fn+main%28%29+%7B%0D%0A++++println%21%28%22Hello%2C+world%21%22%29%3B%0D%0A%7D)
 
 If you're curious, you can also explore how "Hello, world!" looks in other programming languages. [[https://en.wikipedia.org/wiki/%22Hello,_World!%22_program)]](https://en.wikipedia.org/wiki/%22Hello,_World!%22_program)
 
@@ -63,7 +63,7 @@ fn main() {
     println!("{message}");
 }
 ```
-▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&code=fn+main%28%29+%7B%0D%0A++++let+message+%3D+%22Hello%2C+world%21%22%3B%0D%0A%0D%0A++++%2F%2F+Traditional+style+%E2%80%94+compatible+with+all+versions+of+Rust%0D%0A++++println%21%28%22%7B%7D%22%2C+message%29%3B%0D%0A%0D%0A++++%2F%2F+Shorthand+style+%E2%80%94+requires+Rust+1.58+or+newer%0D%0A++++println%21%28%22%7Bmessage%7D%22%29%3B%0D%0A%7D)
+▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=fn+main%28%29+%7B%0D%0A++++let+message+%3D+%22Hello%2C+world%21%22%3B%0D%0A%0D%0A++++%2F%2F+Traditional+style+%E2%80%94+compatible+with+all+versions+of+Rust%0D%0A++++println%21%28%22%7B%7D%22%2C+message%29%3B%0D%0A%0D%0A++++%2F%2F+Shorthand+style+%E2%80%94+requires+Rust+1.58+or+newer%0D%0A++++println%21%28%22%7Bmessage%7D%22%29%3B%0D%0A%7D)
 
 🆕 This is the first example in the guide that uses **inline comments** (starting with `//`) to annotate the code. Comments will be used throughout the guide to explain syntax choices, version compatibility, and behaviors directly within the code samples.
 
@@ -95,7 +95,7 @@ fn main() {
     println!("Hello, {}!", name);
 }
 ```
-▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=407a04b6da4238c4068ae063af793a90)
+▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=407a04b6da4238c4068ae063af793a90)
 
 🆕 This is the first time we’ve used an **import** in Rust, which is done using the `use` keyword:
 
@@ -183,7 +183,7 @@ println!("Hello, {} {}!", fname.trim(), lname.trim());
 
 The `.trim()` method removes the newline characters included by `read_line()` so that the names display cleanly.
 
-▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=e796a9bc9e5735d128185449db6f1151)
+▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=e796a9bc9e5735d128185449db6f1151)
 
 ### ✏️ Exercise: Full Name Flex
 
@@ -202,7 +202,7 @@ println!("Pi to two decimals: {:.2}", pi);
 
 This is equivalent to Python’s `f"{pi:.2f}"`.
 
-▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=c0d0eabc9177e51c62c82d448da8d877)
+▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=c0d0eabc9177e51c62c82d448da8d877)
 
 ## 6. Using `format!` to Store Formatted Strings
 
@@ -216,7 +216,7 @@ println!("{}", greeting);
 
 This is useful when you need to build strings dynamically or return them from functions.
 
-▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&code=fn+main%28%29+%7B%0A++++let+name+%3D+%22Alice%22%3B%0A++++let+greeting+%3D+format%21%28%22Hello%2C+%7Bname%7D%21%22%29%3B%0A++++println%21%28%22%7B%7D%22%2C+greeting%29%3B%0A%7D)
+▶️ [Run in Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=fn+main%28%29+%7B%0A++++let+name+%3D+%22Alice%22%3B%0A++++let+greeting+%3D+format%21%28%22Hello%2C+%7Bname%7D%21%22%29%3B%0A++++println%21%28%22%7B%7D%22%2C+greeting%29%3B%0A%7D)
 
 ### ✏️ Exercise: Save the Message
 

--- a/main/input.md
+++ b/main/input.md
@@ -38,7 +38,7 @@ fn main() {
 
 This simplifies your main logic and avoids boilerplate code.
 
-👉 [Run this example in the Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&code=use+std%3A%3Aio%3A%3A%7Bself%2C+Write%7D%3B%0A%0Afn+input%28prompt%3A+%26str%29+-%3E+String+%7B%0A++++print%21%28%22%7B%7D%22%2C+prompt%29%3B%0A++++io%3A%3Astdout%28%29.flush%28%29.unwrap%28%29%3B%0A%0A++++let+mut+buffer+%3D+String%3A%3Anew%28%29%3B%0A++++io%3A%3Astdin%28%29.read_line%28%26mut+buffer%29.unwrap%28%29%3B%0A++++buffer.trim%28%29.to_string%28%29%0A%7D%0A%0Afn+main%28%29+%7B%0A++++let+name+%3D+input%28%22What+is+your+name%3F+%22%29%3B%0A++++println%21%28%22Hello%2C+%7Bname%7D%21%22%29%3B%0A%7D)
+👉 [Run this example in the Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&code=use+std%3A%3Aio%3A%3A%7Bself%2C+Write%7D%3B%0A%0Afn+input%28prompt%3A+%26str%29+-%3E+String+%7B%0A++++print%21%28%22%7B%7D%22%2C+prompt%29%3B%0A++++io%3A%3Astdout%28%29.flush%28%29.unwrap%28%29%3B%0A%0A++++let+mut+buffer+%3D+String%3A%3Anew%28%29%3B%0A++++io%3A%3Astdin%28%29.read_line%28%26mut+buffer%29.unwrap%28%29%3B%0A++++buffer.trim%28%29.to_string%28%29%0A%7D%0A%0Afn+main%28%29+%7B%0A++++let+name+%3D+input%28%22What+is+your+name%3F+%22%29%3B%0A++++println%21%28%22Hello%2C+%7Bname%7D%21%22%29%3B%0A%7D)
 
 ## 4. Common Extensions
 


### PR DESCRIPTION
## Summary
- update all Rust Playground links to use edition=2021

## Testing
- `cargo test --manifest-path tests/Cargo.toml`