### PR TITLE
Add Claude context file and reference in README

### DIFF
--- a/Claude.md
+++ b/Claude.md
@@ -1,0 +1,3 @@
+# Claude Context
+
+This file provides context for Claude-based assistance when working with this repository.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@ Welcome to the **Rust Tutorial**, a work-in-progress educational resource for le
 
 📘 Start with [`introduction.md`](./main/introduction.md) to get oriented, then move through the lessons in sequence.
 
+AI assistance context files: [`Gemini.md`](./Gemini.md) and [`Claude.md`](./Claude.md).
+
 Your feedback is welcome — suggestions, corrections, and improvements help make this guide better for everyone. You can share your feedback by opening an issue on the GitHub repository: [github.com/pbeens/Rust-Tutorial/issues](https://github.com/pbeens/Rust-Tutorial/issues).


### PR DESCRIPTION
### Motivation

- Add a `Claude.md` context file to provide guidance for Claude-based assistance within the repository.
- Ensure the README references both `Gemini.md` and `Claude.md` so AI assistance context is discoverable.

### Description

- Create `Claude.md` with a brief header and one-line description for Claude-based context.
- Update `README.md` to add the sentence linking to `Gemini.md` and `Claude.md` and preserve the README content.

### Testing

- No automated tests were run on these documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69715148e2648331800cafaf192592c6)